### PR TITLE
Fix broken stock bridge promises and packaging logic

### DIFF
--- a/NeoForge/.gitignore
+++ b/NeoForge/.gitignore
@@ -2,6 +2,8 @@
 .classpath
 .settings
 .eclipse
+.vscode
+.idea
 bin
 build
 codes

--- a/NeoForge/src/main/java/com/tom/stockbridge/ae/AEStockBridgeBlockEntity.java
+++ b/NeoForge/src/main/java/com/tom/stockbridge/ae/AEStockBridgeBlockEntity.java
@@ -2,21 +2,11 @@ package com.tom.stockbridge.ae;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
 
-import net.createmod.catnip.data.Pair;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockState;
-import net.neoforged.neoforge.items.ItemHandlerHelper;
-
 import com.simibubi.create.api.packager.InventoryIdentifier;
 import com.simibubi.create.content.logistics.packager.IdentifiedInventory;
 import com.simibubi.create.content.logistics.packager.PackagerBlockEntity;
 import com.simibubi.create.content.logistics.packager.PackagingRequest;
 import com.simibubi.create.content.logistics.stockTicker.PackageOrderWithCrafts;
-
 import com.tom.stockbridge.util.StockBridgeInventory;
 
 import appeng.api.config.Actionable;
@@ -27,6 +17,14 @@ import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.AEKey;
 import appeng.api.storage.MEStorage;
 import appeng.api.storage.StorageHelper;
+import net.createmod.catnip.data.Pair;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.items.ItemHandlerHelper;
 
 public class AEStockBridgeBlockEntity extends AbstractAEStockBridgeBlockEntity {
 	private StockBridgeInventory inv = new StockBridgeInventory(this);
@@ -43,7 +41,7 @@ public class AEStockBridgeBlockEntity extends AbstractAEStockBridgeBlockEntity {
 			if (grid != null) {
 				final MEStorage networkInv = grid.getStorageService().getInventory();
 				final IEnergyService energySrc = grid.getEnergyService();
-				for (int slot = 0;slot < inv.insertW.getSlots();slot++) {
+				for (int slot = 0; slot < inv.insertW.getSlots(); slot++) {
 					ItemStack is = inv.insertW.getStackInSlot(slot);
 					if (!is.isEmpty()) {
 						AEItemKey what = AEItemKey.of(is);
@@ -62,7 +60,8 @@ public class AEStockBridgeBlockEntity extends AbstractAEStockBridgeBlockEntity {
 	public Pair<PackagerBlockEntity, PackagingRequest> processRequest(ItemStack stack, int amount, String address,
 			int linkIndex, MutableBoolean finalLink, int orderId, PackageOrderWithCrafts context) {
 		final IGrid grid = this.getMainNode().getGrid();
-		if (grid == null) return null;
+		if (grid == null)
+			return null;
 		PackagerBlockEntity packager = getPackager();
 		if (packager == null)
 			return null;
@@ -71,9 +70,15 @@ public class AEStockBridgeBlockEntity extends AbstractAEStockBridgeBlockEntity {
 		final IEnergyService energySrc = grid.getEnergyService();
 
 		var what = AEItemKey.of(stack);
-		final long acquired = StorageHelper.poweredExtraction(energySrc, networkInv, what, amount, actionSource, Actionable.SIMULATE);
+		final long acquired = StorageHelper.poweredExtraction(energySrc, networkInv, what, amount, actionSource,
+				Actionable.SIMULATE);
+
 		var r = ItemHandlerHelper.insertItemStacked(inv.extractW, stack.copyWithCount((int) acquired), true);
 		int count = (int) (acquired - r.getCount());
+
+		if (acquired <= 0 || count <= 0) {
+			return null;
+		}
 
 		return Pair.of(packager,
 				PackagingRequest.create(stack, count, address, linkIndex, finalLink, 0, orderId, context));
@@ -97,16 +102,19 @@ public class AEStockBridgeBlockEntity extends AbstractAEStockBridgeBlockEntity {
 	@Override
 	public void pull(PackagingRequest packagingRequest) {
 		final IGrid grid = this.getMainNode().getGrid();
-		if (grid == null) return;
+		if (grid == null)
+			return;
 		final MEStorage networkInv = grid.getStorageService().getInventory();
 		final IEnergyService energySrc = grid.getEnergyService();
 
 		var what = AEItemKey.of(packagingRequest.item());
 
-		long extracted = StorageHelper.poweredExtraction(energySrc, networkInv, what, packagingRequest.getCount(), actionSource);
-		ItemStack ex = ItemHandlerHelper.insertItemStacked(inv.extractW, packagingRequest.item().copyWithCount((int) extracted), false);
+		long extracted = StorageHelper.poweredExtraction(energySrc, networkInv, what, packagingRequest.getCount(),
+				actionSource);
+		ItemStack ex = ItemHandlerHelper.insertItemStacked(inv.extractW,
+				packagingRequest.item().copyWithCount((int) extracted), false);
 		if (!ex.isEmpty()) {
-			//TODO handle full
+			// TODO handle full
 		}
 		sendPulseNextSync();
 		notifyUpdate();

--- a/NeoForge/src/main/java/com/tom/stockbridge/ae/AEStockBridgeBlockEntity.java
+++ b/NeoForge/src/main/java/com/tom/stockbridge/ae/AEStockBridgeBlockEntity.java
@@ -114,7 +114,8 @@ public class AEStockBridgeBlockEntity extends AbstractAEStockBridgeBlockEntity {
 		ItemStack ex = ItemHandlerHelper.insertItemStacked(inv.extractW,
 				packagingRequest.item().copyWithCount((int) extracted), false);
 		if (!ex.isEmpty()) {
-			// TODO handle full
+			// Force insert the remainder back into ME
+			networkInv.insert(AEItemKey.of(ex), ex.getCount(), Actionable.MODULATE, actionSource);
 		}
 		sendPulseNextSync();
 		notifyUpdate();
@@ -136,6 +137,7 @@ public class AEStockBridgeBlockEntity extends AbstractAEStockBridgeBlockEntity {
 		}
 	}
 
+	@Override
 	public StockBridgeInventory getInv() {
 		return inv;
 	}

--- a/NeoForge/src/main/java/com/tom/stockbridge/util/StockBridgeInventory.java
+++ b/NeoForge/src/main/java/com/tom/stockbridge/util/StockBridgeInventory.java
@@ -2,6 +2,9 @@ package com.tom.stockbridge.util;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.tom.stockbridge.block.entity.AbstractStockBridgeBlockEntity;
+import com.tom.stockbridge.block.entity.AbstractStockBridgeBlockEntity.BridgeInventory;
+
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
@@ -11,12 +14,9 @@ import net.neoforged.neoforge.items.IItemHandler;
 import net.neoforged.neoforge.items.wrapper.CombinedInvWrapper;
 import net.neoforged.neoforge.items.wrapper.InvWrapper;
 
-import com.tom.stockbridge.block.entity.AbstractStockBridgeBlockEntity;
-import com.tom.stockbridge.block.entity.AbstractStockBridgeBlockEntity.BridgeInventory;
-
 public class StockBridgeInventory implements IItemHandler, BridgeInventory {
-	private SimpleContainer insert = new SimpleContainer(9);
-	private SimpleContainer extract = new SimpleContainer(9);
+	private SimpleContainer insert = new SimpleContainer(27);
+	private SimpleContainer extract = new SimpleContainer(27);
 	public InvWrapper insertW = new InvWrapper(insert);
 	public InvWrapper extractW = new InvWrapper(extract);
 

--- a/NeoForge/src/main/resources/csb.mixins.json
+++ b/NeoForge/src/main/resources/csb.mixins.json
@@ -4,11 +4,8 @@
   "package": "com.tom.stockbridge.mixin",
   "compatibilityLevel": "JAVA_17",
   "refmap": "csb.mixins.refmap.json",
-  "mixins": [
-	"PackagerBlockEntityMixin"
-  ],
-  "client": [
-  ],
+  "mixins": ["PackagerBlockEntityMixin", "NetworkStorageMixin"],
+  "client": [],
   "injectors": {
     "defaultRequire": 1
   }

--- a/NeoForge/src/platform-shared/java/com/tom/stockbridge/block/entity/AbstractStockBridgeBlockEntity.java
+++ b/NeoForge/src/platform-shared/java/com/tom/stockbridge/block/entity/AbstractStockBridgeBlockEntity.java
@@ -5,15 +5,6 @@ import java.util.UUID;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
 
-import net.createmod.catnip.data.Iterate;
-import net.createmod.catnip.data.Pair;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.Vec3;
-
 import com.simibubi.create.api.equipment.goggles.IHaveHoveringInformation;
 import com.simibubi.create.content.logistics.packager.IdentifiedInventory;
 import com.simibubi.create.content.logistics.packager.InventorySummary;
@@ -23,8 +14,19 @@ import com.simibubi.create.content.logistics.packagerLink.WiFiParticle;
 import com.simibubi.create.content.logistics.stockTicker.PackageOrderWithCrafts;
 import com.simibubi.create.content.redstone.displayLink.LinkWithBulbBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
+import com.tom.stockbridge.util.StockBridgeInventory;
 
-public abstract class AbstractStockBridgeBlockEntity extends LinkWithBulbBlockEntity implements IHaveHoveringInformation {
+import net.createmod.catnip.data.Iterate;
+import net.createmod.catnip.data.Pair;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+
+public abstract class AbstractStockBridgeBlockEntity extends LinkWithBulbBlockEntity
+		implements IHaveHoveringInformation {
 	public BridgeBehaviour behaviour;
 	public UUID placedBy;
 
@@ -41,7 +43,8 @@ public abstract class AbstractStockBridgeBlockEntity extends LinkWithBulbBlockEn
 
 	public abstract InventorySummary fetchSummaryFromPackager();
 
-	public abstract Pair<PackagerBlockEntity, PackagingRequest> processRequest(ItemStack stack, int amount, String address,
+	public abstract Pair<PackagerBlockEntity, PackagingRequest> processRequest(ItemStack stack, int amount,
+			String address,
 			int linkIndex, MutableBoolean finalLink, int orderId, PackageOrderWithCrafts context);
 
 	public abstract IdentifiedInventory getInvId();
@@ -71,6 +74,8 @@ public abstract class AbstractStockBridgeBlockEntity extends LinkWithBulbBlockEn
 	}
 
 	public abstract void pull(PackagingRequest packagingRequest);
+
+	public abstract StockBridgeInventory getInv();
 
 	@Override
 	public Direction getBulbFacing(BlockState state) {

--- a/NeoForge/src/platform-shared/java/com/tom/stockbridge/mixin/NetworkStorageMixin.java
+++ b/NeoForge/src/platform-shared/java/com/tom/stockbridge/mixin/NetworkStorageMixin.java
@@ -1,0 +1,55 @@
+package com.tom.stockbridge.mixin;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.UUID;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.tom.stockbridge.ae.AbstractAEStockBridgeBlockEntity;
+
+import appeng.api.config.Actionable;
+import appeng.api.networking.security.IActionSource;
+import appeng.api.stacks.AEKey;
+import appeng.api.storage.MEStorage;
+import appeng.me.storage.NetworkStorage;
+
+@Mixin(value = NetworkStorage.class, remap = false)
+public class NetworkStorageMixin {
+  @Shadow
+  private NavigableMap<Integer, List<MEStorage>> priorityInventory;
+
+  @Inject(method = "insert", at = @At("RETURN"))
+  @SuppressWarnings("unused")
+  private void stockbridge_onInsert(AEKey what, long amount, Actionable type, IActionSource src,
+      CallbackInfoReturnable<Long> cir) {
+    if (type == Actionable.MODULATE && cir.getReturnValue() > 0) {
+      // skip things that are manually inserted to the network storage (since they are
+      // probably not promises being resolved)
+      if (src.player().isPresent()) {
+        return;
+      }
+
+      Set<UUID> notifiedNetworks = new HashSet<>();
+      for (var entry : priorityInventory.entrySet()) {
+        for (var storage : entry.getValue()) {
+          if (storage instanceof AbstractAEStockBridgeBlockEntity.BridgeStorage bridgeStorage) {
+            AbstractAEStockBridgeBlockEntity bridge = bridgeStorage.getBridgeBlockEntity();
+            UUID freqId = bridge.behaviour.freqId;
+
+            // Only notify once per Create logistics network
+            if (notifiedNetworks.add(freqId)) {
+              bridge.onItemInserted(what, amount);
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I have been using this mod in a server I am running, but I ran into some issues that made it basically impossible for me to actually use it as intended in my base, so I decided to fix them and open a PR. Mainly, this should address:

- When items are inserted to AE they don't update logistic promises (this caused me so much pain until I figured out that it just wasn't implemented for some reason :sob:)
- Multi-package requests not able to be combined in a re-packager in some cases (mainly when combining with requests outside of AE2)
- The packager only sending out one type of item at a time (now it will do as much as it can fit in one package)

I have my formatter setup to run on save and some of the code changes are probably slightly poorly thought out (mainly dealing with package combining), so if you want to close this and copy some of the code changes yourself or modify this PR I don't mind (I just wanted this to be fixed on my server, and I thought I would contribute the changes in case they're useful).

Fixes #14
Fixes #18
Fixes #22